### PR TITLE
[MAINT] remove doublet compress

### DIFF
--- a/src/qpe_toolbox/tensor/mpomps_tools.py
+++ b/src/qpe_toolbox/tensor/mpomps_tools.py
@@ -161,8 +161,6 @@ def apply_gate_from_mpo(circ, mpo, *, compress=False, cutoff=1e-10, max_bond=0):
 
     """
     psi = mpo.apply(circ.psi, compress=compress, cutoff=cutoff, max_bond=max_bond)
-    if compress:
-        psi.compress(cutoff=cutoff)
     return qtn.CircuitMPS(psi0=psi, cutoff=cutoff, max_bond=max_bond)
 
 


### PR DESCRIPTION
This PR removes a doublet in `tensor.apply_gate_from_mpo` where `compress` was applied twice.