### PR TITLE
[DOC] add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Effort-based versioning](https://jacobtomlinson.dev/effver/)
+
+## [Unreleased]
+
+## [1.0.0] - 2026-03-18
+
+### Added
+
+- Initial public release of `qpe-toolbox`.
+- `circuit` module: `quimb` circuit construction, parametrized circuits, QAOA, gate counting, serialization, and plotting.
+- `hamiltonian` module: `Hamiltonian` class, spin models, `pyscf` interface for molecular chemistry, fermionic encodings via `openfermion`.
+- `estimation` module: textbook and robust QPE variants, LCU walk operators, block encoding, QFT, Hadamard test.
+- `tensor` module: MPS/MPO utilities beyond what `quimb` provides natively.
+- Sphinx documentation deployed to GitHub Pages.
+- Full test suite with ≥ 70 % branch coverage.
+- CI/CD workflows for testing and PyPI publishing.
+
+[Unreleased]: https://github.com/quobly-sw/qpe-toolbox/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/quobly-sw/qpe-toolbox/releases/tag/v1.0.0

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,0 +1,2 @@
+```{include} ../../CHANGELOG.md
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -51,13 +51,19 @@ manipulation of Matrix Product Operators (MPO) and Matrix Product States (MPS).
 
 ```{toctree}
 :maxdepth: 1
-:caption: Contents
+:caption: Guides
 
 Installation Guide <customapi/installation/index>
 
 Basic Workflow <customapi/workflow/index>
 
 Tutorials <customapi/tutorials/index>
+```
+
+```{toctree}
+:maxdepth: 1
+:caption: Development
+Changelog <changelog>
 
 GitHub Repository <https://github.com/quobly-sw/qpe-toolbox>
 


### PR DESCRIPTION
This PR adds `CHANGELOG.md` in the top directory and includes it within the doc. Also updates the documentation table of contents.