### PR TITLE
[DX] use uv in format hook

### DIFF
--- a/.github/workflows/ruff-format_action.yaml
+++ b/.github/workflows/ruff-format_action.yaml
@@ -19,6 +19,6 @@ jobs:
     - name: format src
       run: uv run --no-sync ruff format --check
 
-    # use pre-commit as task runner to activate venv for hook
+    # use pre-commit as task runner to get clean pass/fail status
     - name: format notebooks
       run: uv run --no-sync pre-commit run format-examples --all-files

--- a/hooks/format_notebooks.sh
+++ b/hooks/format_notebooks.sh
@@ -17,6 +17,6 @@ mkdir -p jupyter_execute
 rm -f jupyter_execute/*ipynb
 
 # jupytext working dir is the one of the notebook, need relative  path from examples/
-jupytext -q --to ../jupyter_execute//ipynb $@
-ruff format jupyter_execute/*ipynb
-jupytext -q --to ../examples//py jupyter_execute/*ipynb
+uv run jupytext -q --to ../jupyter_execute//ipynb $@
+uv run ruff format jupyter_execute/*ipynb
+uv run jupytext -q --to ../examples//py jupyter_execute/*ipynb


### PR DESCRIPTION
This PR updates `format-examples` hook in order to use `uv run` there.

Previously, I avoided calling `uv` there to avoid forcing developers to install `uv`. However it means coming back to all the difficulties of virtual environment detection. It worked when calling `uv run pre-commit` which activates the venv, so the CI wqs fine. However `uv run pre-commit install` still causes `git commit` to directly call `pre-commit`: if the venv is not activated, `jupytext` is not found and the hook fails. This was a source of difficulties to start working on the repo.

With this PR, the hook `format-examples.sh` calls `ruff` and `jupytext` through `uv run`, removing all the headaches of venv management. It means `uv` must be here for the hook to work (previously we assumed `jupytext` and `ruff` where in `PATH`). Since we already use `uv` in the developpment process (CI + `uv.lock`), this looks reasonable. One can still decide not to use `pre-commit` at all and commit without calling `uv`.