### PR TITLE
[CI] fix pytest warning

### DIFF
--- a/.github/workflows/pytest_action.yaml
+++ b/.github/workflows/pytest_action.yaml
@@ -18,7 +18,7 @@ jobs:
         python-version: "3.13"
 
     - name: Install the project
-      run: uv sync --locked --group=test --no-default-groups
+      run: uv sync --locked --group=test --no-default-groups --extra recommended
 
     - name: Run tests
       run: uv run --no-sync pytest -n auto -v --deselect tests/test_examples.py --durations=0 --durations-min=0.5 --color=yes --cov-report=html


### PR DESCRIPTION
Fix missing `kahypar` warning observed in https://github.com/quobly-sw/qpe-toolbox/actions/runs/29920756410/job/88925361294